### PR TITLE
Remove debug assertion in lookup

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -107,8 +107,6 @@ impl<T, A: Array<Item=Entry<T>>> LRUCache<T, A> {
             None => None,
             Some((i, r)) => {
                 self.touch(i);
-                let front = self.front_mut().unwrap();
-                debug_assert!(test_one(front).is_some());
                 Some(r)
             }
         }


### PR DESCRIPTION
If the test callback has side effects, this could cause subtle behavior differences in debug builds.