### PR TITLE
Simplify public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uluru"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 description = "A simple, fast, LRU cache implementation"

--- a/lib.rs
+++ b/lib.rs
@@ -67,10 +67,6 @@ pub struct LRUCache<A: Array> {
     tail: u16,
 }
 
-/// An opaque token used as an index into an LRUCache.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-struct CacheIndex(u16);
-
 /// An entry in an LRUCache.
 pub struct Entry<T> {
     val: T,
@@ -100,10 +96,10 @@ impl<T, A: Array<Item=Entry<T>>> LRUCache<A> {
 
     #[inline]
     /// Touch a given entry, putting it first in the list.
-    fn touch(&mut self, idx: CacheIndex) {
-        if idx.0 != self.head {
-            self.remove(idx.0);
-            self.push_front(idx.0);
+    fn touch(&mut self, idx: u16) {
+        if idx != self.head {
+            self.remove(idx);
+            self.push_front(idx);
         }
     }
 
@@ -242,7 +238,7 @@ impl<'a, T, A> Iterator for LRUCacheMutIterator<'a, A>
 where T: 'a,
       A: 'a + Array<Item=Entry<T>>
 {
-    type Item = (CacheIndex, &'a mut T);
+    type Item = (u16, &'a mut T);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.done { return None }
@@ -252,7 +248,7 @@ where T: 'a,
             &mut *(&mut self.cache.entries[self.pos as usize] as *mut Entry<T>)
         };
 
-        let index = CacheIndex(self.pos);
+        let index = self.pos;
         if self.pos == self.cache.tail {
             self.done = true;
         }

--- a/lib.rs
+++ b/lib.rs
@@ -69,7 +69,7 @@ pub struct LRUCache<A: Array> {
 
 /// An opaque token used as an index into an LRUCache.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct CacheIndex(u16);
+struct CacheIndex(u16);
 
 /// An entry in an LRUCache.
 pub struct Entry<T> {
@@ -100,7 +100,7 @@ impl<T, A: Array<Item=Entry<T>>> LRUCache<A> {
 
     #[inline]
     /// Touch a given entry, putting it first in the list.
-    pub fn touch(&mut self, idx: CacheIndex) {
+    fn touch(&mut self, idx: CacheIndex) {
         if idx.0 != self.head {
             self.remove(idx.0);
             self.push_front(idx.0);
@@ -117,18 +117,8 @@ impl<T, A: Array<Item=Entry<T>>> LRUCache<A> {
         self.entries.get_mut(self.head as usize).map(|e| &mut e.val)
     }
 
-    /// Iterate over the contents of this cache, from more to less recently
-    /// used.
-    pub fn iter(&self) -> LRUCacheIterator<A> {
-        LRUCacheIterator {
-            pos: self.head,
-            done: self.entries.len() == 0,
-            cache: self,
-        }
-    }
-
     /// Iterate mutably over the contents of this cache.
-    pub fn iter_mut(&mut self) -> LRUCacheMutIterator<A> {
+    fn iter_mut(&mut self) -> LRUCacheMutIterator<A> {
         LRUCacheMutIterator {
             pos: self.head,
             done: self.entries.len() == 0,
@@ -241,36 +231,8 @@ impl<T, A: Array<Item=Entry<T>>> LRUCache<A> {
     }
 }
 
-/// Immutable iterator over values in an LRUCache, from most-recently-used to least-recently-used.
-pub struct LRUCacheIterator<'a, A: 'a + Array> {
-    cache: &'a LRUCache<A>,
-    pos: u16,
-    done: bool,
-}
-
-impl<'a, T, A> Iterator for LRUCacheIterator<'a, A>
-where T: 'a,
-      A: 'a + Array<Item=Entry<T>>
-{
-    type Item = (CacheIndex, &'a T);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.done { return None }
-
-        let entry = &self.cache.entries[self.pos as usize];
-
-        let index = CacheIndex(self.pos);
-        if self.pos == self.cache.tail {
-            self.done = true;
-        }
-        self.pos = entry.next;
-
-        Some((index, &entry.val))
-    }
-}
-
 /// Mutable iterator over values in an LRUCache, from most-recently-used to least-recently-used.
-pub struct LRUCacheMutIterator<'a, A: 'a + Array> {
+struct LRUCacheMutIterator<'a, A: 'a + Array> {
     cache: &'a mut LRUCache<A>,
     pos: u16,
     done: bool,

--- a/tests.rs
+++ b/tests.rs
@@ -6,19 +6,19 @@ use super::*;
 type TestCache = LRUCache<[Entry<i32>; 4]>;
 
 /// Convenience function for test assertions
-fn items<T, A>(cache: &LRUCache<A>) -> Vec<T>
+fn items<T, A>(cache: &mut LRUCache<A>) -> Vec<T>
 where
     T: Clone,
     A: Array<Item=Entry<T>>
 {
-    cache.iter().map(|(_, x)| x.clone()).collect()
+    cache.iter_mut().map(|(_, x)| x.clone()).collect()
 }
 
 #[test]
 fn empty() {
-    let cache = TestCache::default();
+    let mut cache = TestCache::default();
     assert_eq!(cache.num_entries(), 0);
-    assert_eq!(items(&cache), []);
+    assert_eq!(items(&mut cache), []);
 }
 
 #[test]
@@ -32,17 +32,17 @@ fn insert() {
     assert_eq!(cache.num_entries(), 3);
     cache.insert(4);
     assert_eq!(cache.num_entries(), 4);
-    assert_eq!(items(&cache), [4, 3, 2, 1], "Ordered from most- to least-recent.");
+    assert_eq!(items(&mut cache), [4, 3, 2, 1], "Ordered from most- to least-recent.");
 
     cache.insert(5);
     assert_eq!(cache.num_entries(), 4);
-    assert_eq!(items(&cache), [5, 4, 3, 2], "Least-recently-used item evicted.");
+    assert_eq!(items(&mut cache), [5, 4, 3, 2], "Least-recently-used item evicted.");
 
     cache.insert(6);
     cache.insert(7);
     cache.insert(8);
     cache.insert(9);
-    assert_eq!(items(&cache), [9, 8, 7, 6], "Least-recently-used item evicted.");
+    assert_eq!(items(&mut cache), [9, 8, 7, 6], "Least-recently-used item evicted.");
 }
 
 #[test]
@@ -55,12 +55,12 @@ fn lookup() {
 
     let result = cache.lookup(|x| if *x == 5 { Some(()) } else { None });
     assert_eq!(result, None, "Cache miss.");
-    assert_eq!(items(&cache), [4, 3, 2, 1], "Order not changed.");
+    assert_eq!(items(&mut cache), [4, 3, 2, 1], "Order not changed.");
 
     // Cache hit
     let result = cache.lookup(|x| if *x == 3 { Some(*x * 2) } else { None });
     assert_eq!(result, Some(6), "Cache hit.");
-    assert_eq!(items(&cache), [3, 4, 2, 1], "Matching item moved to front.");
+    assert_eq!(items(&mut cache), [3, 4, 2, 1], "Matching item moved to front.");
 }
 
 #[test]
@@ -68,14 +68,14 @@ fn evict_all() {
     let mut cache = TestCache::default();
     cache.insert(1);
     cache.evict_all();
-    assert_eq!(items(&cache), [], "all items evicted");
+    assert_eq!(items(&mut cache), [], "all items evicted");
 
     cache.insert(1);
     cache.insert(2);
     cache.insert(3);
     cache.insert(4);
-    assert_eq!(items(&cache), [4, 3, 2, 1]);
+    assert_eq!(items(&mut cache), [4, 3, 2, 1]);
     cache.evict_all();
-    assert_eq!(items(&cache), [], "all items evicted again");
+    assert_eq!(items(&mut cache), [], "all items evicted again");
 }
 


### PR DESCRIPTION
Remove the `iter`, `iter_mut`, and `touch` methods.  These are now internal implementation details.  Users should use the `find` or `lookup` methods instead.