### PR TITLE
Remove unsafe code in IterMut

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Servo's style system.
 
 `LRUCache` uses a fixed-capacity array for storage. It provides `O(1)`
 insertion, and `O(n)` lookup.  It does not require an allocator and can be
-used in `no_std` crates.
+used in `no_std` crates.  It is implemented in 100% safe Rust.
 
 * [Documentation](https://docs.rs/uluru)
 * [crates.io](https://crates.io/crates/uluru)

--- a/tests.rs
+++ b/tests.rs
@@ -11,7 +11,12 @@ where
     T: Clone,
     A: Array<Item = Entry<T>>,
 {
-    cache.iter_mut().map(|(_, x)| x.clone()).collect()
+    let mut v = Vec::new();
+    let mut iter = cache.iter_mut();
+    while let Some((_idx, val)) = iter.next() {
+        v.push(val.clone())
+    }
+    v
 }
 
 #[test]


### PR DESCRIPTION
By making `IterMut` a "streaming" iterator, we can simplify its implementation and remove the unsafe code, because we no longer need to prove that each item it yields is unique.

With this change, uluru is now implemented in 100% safe Rust.

r? @jdm