### PR TITLE
Draft: const generics version of uluru

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ readme = "README.md"
 name = "uluru"
 path = "lib.rs"
 
-[dependencies]
-arrayvec = { version = "0.5", default-features = false } # public dependency
+[dependencies.arrayvec]
+git = "https://github.com/mbrubeck/arrayvec"
+branch = "min-const-gen"
+default-features = false
+features = ["unstable-const-generics"]
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/tests.rs
+++ b/tests.rs
@@ -3,13 +3,12 @@ extern crate std;
 use self::std::vec::Vec;
 use super::*;
 
-type TestCache = LRUCache<[Entry<i32>; 4]>;
+type TestCache = LRUCache<i32, 4>;
 
 /// Convenience function for test assertions
-fn items<T, A>(cache: &mut LRUCache<A>) -> Vec<T>
+fn items<T, const N: usize>(cache: &mut LRUCache<T, N>) -> Vec<T>
 where
     T: Clone,
-    A: Array<Item = Entry<T>>,
 {
     let mut v = Vec::new();
     let mut iter = cache.iter_mut();


### PR DESCRIPTION
This depends on the `min_const_generics` feature which is scheduled to stabilize in Rust 1.51, and on https://github.com/bluss/arrayvec/pull/172.