### PR TITLE
Access to item by index

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,18 @@ impl<T, const N: usize> LRUCache<T, N> {
         self.entries.get_mut(self.head as usize).map(|e| &mut e.val)
     }
 
+    /// Returns the n-th entry in the list (most recently used).
+    pub fn get(&self, index: usize) -> Option<&T> {
+        if index >= self.len() {
+            return None;
+        }
+        let mut entry = self.entries.get(self.head as usize)?;
+        for _ in 0..index {
+            entry = self.entries.get(entry.next as usize)?;
+        }
+        Some(&entry.val)
+    }
+
     /// Touches the first item in the cache that matches the given predicate.
     /// Returns `true` on a hit, `false` if no matches.
     pub fn touch<F>(&mut self, mut pred: F) -> bool

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -176,3 +176,40 @@ fn front() {
         "Touched item should be in the front."
     );
 }
+
+
+#[test]
+fn get() {
+    let mut cache = TestCache::default();
+
+    assert_eq!(cache.get(0), None, "Nothing at index 0.");
+
+    cache.insert(42);
+    cache.insert(64);
+
+    assert_eq!(
+        cache.get(0),
+        Some(&64),
+        "The last inserted item should be at index 0."
+    );
+
+    assert_eq!(
+        cache.get(1),
+        Some(&42),
+        "The first inserted item should be at index 1."
+    );
+
+    cache.touch(|x| *x == 42);
+
+    assert_eq!(
+        cache.get(0),
+        Some(&42),
+        "The last touched item should be at index 0."
+    );
+
+    assert_eq!(
+        cache.get(1),
+        Some(&64),
+        "The previously front item should be at index 1."
+    );
+}


### PR DESCRIPTION
New method added to access item in LRU list by index.

This feature is useful for traverse list in least-recently-used order. 