### PR TITLE
Add support for returning displaced entries for re-use.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,9 @@ categories = ["data-structures", "no-std"]
 readme = "README.md"
 include = ["src/**/*", "LICENSE", "README.md"]
 
+[features]
+default = []
+std = []
+
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Servo's style system.
 insertion, and `O(n)` lookup.  It does not require an allocator and can be
 used in `no_std` crates.  It is implemented in 100% safe Rust.
 
+## Cargo Features
+
+By default, this crate won't need the standard library. However, if the `std` cargo feature is enabled, `insert()` will
+return a replaced value which allows to reuse memory it may have contained.
+
 * [Documentation](https://docs.rs/uluru)
 * [crates.io](https://crates.io/crates/uluru)
 * [Release notes](https://github.com/servo/uluru/releases)


### PR DESCRIPTION
I added this to be able to avoid allocations if the entry is allocating, In case of `gitoxide` this saves a couple of millions of allocations in favour of a few thousand re-allocs.

Performance wasn't measurably better in my case, just as if the allocator can already repurpose previously freed slabs of memory pretty well or at only a very low cost.

Since it doesn't seem to hurt providing this capability, I am creating this PR anyway in the hopes it does indeed make sense to some in this form or another.

Please let me know :).